### PR TITLE
Custom editor added. Multiple start node support added

### DIFF
--- a/Assets/AddressableAssetsData/AssetGroups/Localization-Assets-Shared.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Localization-Assets-Shared.asset
@@ -23,6 +23,12 @@ MonoBehaviour:
     m_ReadOnly: 1
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: c2bd177689020fd468d2d17b65acc54e
+    m_Address: Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New
+      Table 2 Shared Data.asset
+    m_ReadOnly: 1
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   m_ReadOnly: 1
   m_Settings: {fileID: 11400000, guid: 45bcaa0f9119bdc44b426e7814210719, type: 2}
   m_SchemaSet:

--- a/Assets/AddressableAssetsData/AssetGroups/Localization-String-Tables-English (en).asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Localization-String-Tables-English (en).asset
@@ -23,6 +23,12 @@ MonoBehaviour:
     m_SerializedLabels:
     - Locale-en
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 5f49daacee4b45b4a94f58f3c7c49cb7
+    m_Address: New Table 2_en
+    m_ReadOnly: 1
+    m_SerializedLabels:
+    - Locale-en
+    FlaggedDuringContentUpdateRestriction: 0
   m_ReadOnly: 1
   m_Settings: {fileID: 11400000, guid: 45bcaa0f9119bdc44b426e7814210719, type: 2}
   m_SchemaSet:

--- a/Assets/AddressableAssetsData/AssetGroups/Localization-String-Tables-Japanese (ja).asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Localization-String-Tables-Japanese (ja).asset
@@ -23,6 +23,12 @@ MonoBehaviour:
     m_SerializedLabels:
     - Locale-ja
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: b3f1e7a888bb1cd4480171a27de7c79d
+    m_Address: New Table 2_ja
+    m_ReadOnly: 1
+    m_SerializedLabels:
+    - Locale-ja
+    FlaggedDuringContentUpdateRestriction: 0
   m_ReadOnly: 1
   m_Settings: {fileID: 11400000, guid: 45bcaa0f9119bdc44b426e7814210719, type: 2}
   m_SchemaSet:

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/CHANGELOG.md
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## [v0.3.10] - 2023-3-22
+1. Can write dialogue without needing to setup/open localized string
+1. Dialogue is synced with localized string.
+1. Custom dialogue node Editor class added.
+1. Multiple start nodes for dialogue
+1. Dialogue Start Helper class with custom editor that shows all start nodes and allows selecting one of them.
 ## [v0.3.1] - 2023-4-1
 1. Dialogue nodes now used localized strings
 2. Sample scene updated with UI that supports localized strings

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueBaseNodeEditor.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueBaseNodeEditor.cs
@@ -23,5 +23,6 @@ namespace Studio23.SS2.DialogueSystem.Data
             base.OnBodyGUI();
             EditorStyles.label.normal = editorLabelStyle.normal;
         }
+        
     }
 }

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueBaseNodeEditor.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueBaseNodeEditor.cs
@@ -22,8 +22,6 @@ namespace Studio23.SS2.DialogueSystem.Data
             EditorStyles.label.normal.textColor = TextColor;
             base.OnBodyGUI();
             EditorStyles.label.normal = editorLabelStyle.normal;
-
         }
-        
     }
 }

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueBaseNodeEditor.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueBaseNodeEditor.cs
@@ -22,6 +22,7 @@ namespace Studio23.SS2.DialogueSystem.Data
             EditorStyles.label.normal.textColor = TextColor;
             base.OnBodyGUI();
             EditorStyles.label.normal = editorLabelStyle.normal;
+
         }
         
     }

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueLineNodeEditor.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueLineNodeEditor.cs
@@ -1,0 +1,40 @@
+using UnityEditor;
+using UnityEditor.Localization;
+using UnityEngine;
+using UnityEngine.Localization.Settings;
+using UnityEngine.Localization.Tables;
+using XNodeEditor;
+
+namespace Studio23.SS2.DialogueSystem.Data
+{
+    [CustomNodeEditor(typeof(DialogueLineNodeBase))]
+    public class DialogueLineNodeEditor : NodeEditor
+    {
+
+        public static string DEFAULT_LOCALE = "en";
+
+        public override void OnBodyGUI()
+        {
+            var dialogueLineNode = target as DialogueLineNodeBase;
+            
+            var collection = LocalizationEditorSettings.GetStringTableCollection(dialogueLineNode.DialogueLocalizedString.TableReference);
+            var englishTable = collection.GetTable(DEFAULT_LOCALE) as StringTable;
+            var entry = englishTable.GetEntry(dialogueLineNode.DialogueLocalizedString.TableEntryReference.KeyId);
+
+            var prevText = entry.Value;
+            var text = EditorGUILayout.TextArea(prevText);
+            if (prevText != text)
+            {
+                Debug.Log($"{prevText} -> {text}");
+                englishTable.AddEntry(dialogueLineNode.DialogueLocalizedString.TableEntryReference.KeyId, text);
+                // prevText = e.Value
+                // dialogueLineNode.DialogueLocalizedString.se
+                // dialogueLineNode.DialogueLocalizedString
+            }
+            // Update serialized object's representation
+            serializedObject.Update();
+            base.OnBodyGUI();
+        }
+        
+    }
+}

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueLineNodeEditor.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueLineNodeEditor.cs
@@ -14,7 +14,7 @@ namespace Studio23.SS2.DialogueSystem.Data
     {
 
         public static string DEFAULT_LOCALE = "en";
-        private string _prevText;
+        private string _text;
 
         public override void OnBodyGUI()
         {
@@ -28,8 +28,9 @@ namespace Studio23.SS2.DialogueSystem.Data
             var entry = englishTable.GetEntry(dialogueLineNode.DialogueLocalizedString.TableEntryReference.KeyId);
             if (entry == null)
             {
-                _prevText = EditorGUILayout.TextArea(_prevText);
-                if(string.IsNullOrEmpty(_prevText))
+                _text = EditorGUILayout.TextArea(_text);
+                
+                if(string.IsNullOrEmpty(_text))
                 {
                     EditorGUILayout.HelpBox("Write something", MessageType.Warning);
                 }
@@ -38,15 +39,16 @@ namespace Studio23.SS2.DialogueSystem.Data
                     if (GUILayout.Button("Create localized line"))
                     {
                         // var key = collection.SharedData.KeyGenerator.GetNextKey();
-                        var key = _prevText.Substring(0, Mathf.Min(10, _prevText.Length));
+                        var key = _text.Substring(0, Mathf.Min(10, _text.Length));
                         collection.SharedData.AddKey(key);
-                        entry = englishTable.AddEntry(key, _prevText);
-                        Debug.Log($"new dialogue line entry {_prevText}");
+                        entry = englishTable.AddEntry(key, _text);
+                        
+                        Debug.Log($"new dialogue line entry {_text}");
+                        
                         englishTable.SaveChanges();
-
+                        
                         dialogueLineNode.DialogueLocalizedString =
                             new LocalizedString(collection.SharedData.TableCollectionNameGuid, entry.KeyId);
-                        
                         EditorUtility.SetDirty(dialogueLineNode);
                     }
                 }
@@ -54,22 +56,26 @@ namespace Studio23.SS2.DialogueSystem.Data
             }
             else
             {
-                _prevText = entry.Value;
-                var text = EditorGUILayout.TextArea(_prevText);
-                if (_prevText != text)
+                var localizedText = entry.Value;
+                if (string.IsNullOrEmpty(_text))
+                {
+                    _text = localizedText;
+                }
+                _text = EditorGUILayout.TextArea(_text);
+                if (_text != localizedText)
                 {
                     EditorGUILayout.HelpBox("Localized string doesn't match. PLEASE SAVE", MessageType.Warning);
                     if (GUILayout.Button("SAVE"))
                     {
-                        Debug.Log($"{_prevText} -> {text}");
-                        _prevText = text;
-                        englishTable.SetEntry(dialogueLineNode.DialogueLocalizedString, text);
+                        Debug.Log($"{localizedText} -> {_text}");
+                        englishTable.SetEntry(dialogueLineNode.DialogueLocalizedString, _text);
                         englishTable.SaveChanges();
+                        dialogueLineNode.DialogueLocalizedString.RefreshString();
+                        EditorUtility.SetDirty(dialogueLineNode);
+                    }else if (GUILayout.Button("RESET"))
+                    {
+                        _text = localizedText;
                     }
-
-                    // prevText = e.Value
-                    // dialogueLineNode.DialogueLocalizedString.se
-                    // dialogueLineNode.DialogueLocalizedString
                 }
             }
             

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueLineNodeEditor.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueLineNodeEditor.cs
@@ -39,17 +39,7 @@ namespace Studio23.SS2.DialogueSystem.Data
                     if (GUILayout.Button("Create localized line"))
                     {
                         // var key = collection.SharedData.KeyGenerator.GetNextKey();
-                        var key = _text.Substring(0, Mathf.Min(10, _text.Length));
-                        collection.SharedData.AddKey(key);
-                        entry = englishTable.AddEntry(key, _text);
-                        
-                        Debug.Log($"new dialogue line entry {_text}");
-                        
-                        englishTable.SaveChanges();
-                        
-                        dialogueLineNode.DialogueLocalizedString =
-                            new LocalizedString(collection.SharedData.TableCollectionNameGuid, entry.KeyId);
-                        EditorUtility.SetDirty(dialogueLineNode);
+                        CreateNewEntry(collection, englishTable, dialogueLineNode);
                     }
                 }
                 
@@ -77,11 +67,31 @@ namespace Studio23.SS2.DialogueSystem.Data
                         _text = localizedText;
                     }
                 }
+                if (GUILayout.Button("Replace with new Entry"))
+                {
+                    CreateNewEntry(collection, englishTable, dialogueLineNode);
+                }
             }
             
 
             base.OnBodyGUI();
         }
-        
+
+        private void CreateNewEntry(StringTableCollection collection, StringTable englishTable,
+            DialogueLineNodeBase dialogueLineNode)
+        {
+            StringTableEntry entry;
+            var key = _text.Substring(0, Mathf.Min(10, _text.Length));
+            collection.SharedData.AddKey(key);
+            entry = englishTable.AddEntry(key, _text);
+                        
+            Debug.Log($"new dialogue line entry {_text}");
+                        
+            englishTable.SaveChanges();
+                        
+            dialogueLineNode.DialogueLocalizedString =
+                new LocalizedString(collection.SharedData.TableCollectionNameGuid, entry.KeyId);
+            EditorUtility.SetDirty(dialogueLineNode);
+        }
     }
 }

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueLineNodeEditor.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueLineNodeEditor.cs
@@ -2,6 +2,7 @@ using Studio23.SS2.DialogueSystem.Utility;
 using UnityEditor;
 using UnityEditor.Localization;
 using UnityEngine;
+using UnityEngine.Localization;
 using UnityEngine.Localization.Settings;
 using UnityEngine.Localization.Tables;
 using XNodeEditor;
@@ -17,6 +18,9 @@ namespace Studio23.SS2.DialogueSystem.Data
 
         public override void OnBodyGUI()
         {
+            // Update serialized object's representation
+            serializedObject.Update();
+            
             var dialogueLineNode = target as DialogueLineNodeBase;
             
             var collection = LocalizationEditorSettings.GetStringTableCollection(dialogueLineNode.DialogueLocalizedString.TableReference);
@@ -33,10 +37,17 @@ namespace Studio23.SS2.DialogueSystem.Data
                 {
                     if (GUILayout.Button("Create localized line"))
                     {
-                        var key = collection.SharedData.KeyGenerator.GetNextKey();
-                        englishTable.AddEntry(key, _prevText);
+                        // var key = collection.SharedData.KeyGenerator.GetNextKey();
+                        var key = _prevText.Substring(0, Mathf.Min(10, _prevText.Length));
+                        collection.SharedData.AddKey(key);
+                        entry = englishTable.AddEntry(key, _prevText);
                         Debug.Log($"new dialogue line entry {_prevText}");
                         englishTable.SaveChanges();
+
+                        dialogueLineNode.DialogueLocalizedString =
+                            new LocalizedString(collection.SharedData.TableCollectionNameGuid, entry.KeyId);
+                        
+                        EditorUtility.SetDirty(dialogueLineNode);
                     }
                 }
                 
@@ -51,6 +62,7 @@ namespace Studio23.SS2.DialogueSystem.Data
                     if (GUILayout.Button("SAVE"))
                     {
                         Debug.Log($"{_prevText} -> {text}");
+                        _prevText = text;
                         englishTable.SetEntry(dialogueLineNode.DialogueLocalizedString, text);
                         englishTable.SaveChanges();
                     }
@@ -61,8 +73,7 @@ namespace Studio23.SS2.DialogueSystem.Data
                 }
             }
             
-            // Update serialized object's representation
-            serializedObject.Update();
+
             base.OnBodyGUI();
         }
         

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueLineNodeEditor.cs.meta
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/DialogueLineNodeEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d43dc5d735594140aeda05133cedf58
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/LocalizationExtensions.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/LocalizationExtensions.cs
@@ -1,0 +1,20 @@
+using UnityEditor;
+using UnityEngine.Localization;
+using UnityEngine.Localization.Tables;
+
+namespace Studio23.SS2.DialogueSystem.Utility
+{
+    public static class LocalizationExtensions
+    {
+        public static void SetEntry(this StringTable table, LocalizedString localizedString, string newText)
+        {
+            table.AddEntry(localizedString.TableEntryReference.KeyId, newText);
+        }
+        
+        public static void SaveChanges(this StringTable table)
+        {
+            EditorUtility.SetDirty(table.SharedData);
+            EditorUtility.SetDirty(table);
+        }
+    }
+}

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/LocalizationExtensions.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/LocalizationExtensions.cs
@@ -1,4 +1,5 @@
 using UnityEditor;
+using UnityEditor.Localization;
 using UnityEngine.Localization;
 using UnityEngine.Localization.Tables;
 
@@ -15,6 +16,25 @@ namespace Studio23.SS2.DialogueSystem.Utility
         {
             EditorUtility.SetDirty(table.SharedData);
             EditorUtility.SetDirty(table);
+        }
+        /// <summary>
+        /// Use this to get localized string value in editor
+        /// for whatever reason notmal getString doesn't work
+        /// </summary>
+        /// <param name="localizedString"></param>
+        /// <param name="locale"></param>
+        /// <returns></returns>
+        public static string GetLocalizedStringInEditor(this LocalizedString localizedString, string locale = "en")
+        {
+            var collection = LocalizationEditorSettings.GetStringTableCollection(localizedString.TableReference);
+            var englishTable = collection.GetTable(locale) as StringTable;
+            var entry = englishTable.GetEntry(localizedString.TableEntryReference.KeyId);
+            if (entry == null)
+            {
+                return null;
+            }
+
+            return entry.Value;
         }
     }
 }

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/LocalizationExtensions.cs.meta
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/Data/LocalizationExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c950e442acfa490a8a241e5f9b97b5e3
+timeCreated: 1710212173

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/com.studio23.ss2.dialoguesystem.editor.asmdef
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Editor/com.studio23.ss2.dialoguesystem.editor.asmdef
@@ -4,7 +4,9 @@
     "references": [
         "GUID:3e1deda3cfa83394e827391555d95b6f",
         "GUID:b8e24fd1eb19b4226afebb2810e3c19b",
-        "GUID:002c1bbed08fa44d282ef34fd5edb138"
+        "GUID:002c1bbed08fa44d282ef34fd5edb138",
+        "GUID:eec0964c48f6f4e40bc3ec2257ccf8c5",
+        "GUID:2e77701fe0ceda44fb763f03ee704c37"
     ],
     "includePlatforms": [
         "Editor"

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Runtime/Core/DialogueSystem.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Runtime/Core/DialogueSystem.cs
@@ -63,6 +63,11 @@ namespace Studio23.SS2.DialogueSystem.Core
         {
             PlayDialogue(graph);
         }
+        
+        public void StartDialogue(DialogueGraph graph, DialogueNodeBase startNode)
+        {
+            PlayDialogue(graph, startNode);
+        }
 
         public void StartDialogue()
         {
@@ -71,16 +76,20 @@ namespace Studio23.SS2.DialogueSystem.Core
 
         public async UniTask PlayDialogue(DialogueGraph graph)
         {
+            PlayDialogue(graph, graph.StartNode);
+        }
+        
+        public async UniTask PlayDialogue(DialogueGraph graph, DialogueNodeBase startNode)
+        {
             _currentGraph = graph;
             _currentGraph.Initialize();
-            
             _currentGraph.HandleDialogueStarted();
-            OnDialogueStarted?.Invoke(_currentGraph);
             
-            _curNode = _currentGraph.StartNode;
+            _curNode = startNode;
+            OnDialogueStarted?.Invoke(_currentGraph);
             while (_curNode != null)
             {
-                Debug.Log("node = " + _curNode, _curNode);
+                Debug.Log("Play = " + _curNode, _curNode);
                 await _curNode.Play();
                 
                 _curNode = _curNode.GetNextNode();

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Runtime/Data/xNode/Graph/DialogueGraph.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Runtime/Data/xNode/Graph/DialogueGraph.cs
@@ -64,8 +64,6 @@ namespace Studio23.SS2.DialogueSystem.Data
             return false;
         }
 
-
-
         public void Initialize()
         {
             if (_initialized)

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Runtime/Data/xNode/Graph/DialogueGraph.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Runtime/Data/xNode/Graph/DialogueGraph.cs
@@ -62,8 +62,9 @@ namespace Studio23.SS2.DialogueSystem.Data
             {
                 if (node is DialogueLineNodeBase dialogueLineNodeBase)
                 {
-                    if (string.IsNullOrEmpty(table.TableCollectionName))
+                    if (string.IsNullOrEmpty(dialogueLineNodeBase.GetLocalizationTable().TableCollectionName))
                     {
+                        Debug.LogWarning($"{dialogueLineNodeBase} replace table to {table}");
                         dialogueLineNodeBase.SetLocalizationTable(table);
                     }
                 }

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Runtime/Data/xNode/Graph/DialogueGraph.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Runtime/Data/xNode/Graph/DialogueGraph.cs
@@ -28,7 +28,7 @@ namespace Studio23.SS2.DialogueSystem.Data
         private bool _initialized = false;
         public event Action<DialogueGraph> OnDialogueStarted;
         public event Action<DialogueGraph> OnDialogueEnded;
-        [SerializeField] private TableReference _defaultTable;
+
 
         public override Node AddNode(Type type)
         {
@@ -47,7 +47,7 @@ namespace Studio23.SS2.DialogueSystem.Data
             var firstNode = FindStartNode() as DialogueLineNodeBase;
             if (firstNode != null)
             {
-                firstNode.GetLocalizationTable();
+                return firstNode.GetLocalizationTable();
             }
 
             return default;

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Runtime/Data/xNode/Graph/DialogueGraph.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Runtime/Data/xNode/Graph/DialogueGraph.cs
@@ -64,25 +64,7 @@ namespace Studio23.SS2.DialogueSystem.Data
             return false;
         }
 
-        [ContextMenu("SET ALL DIALOGUE TABLES")]
-        public void SetAllDialogueTables()
-        {
-            if (!TryGetDefaultTable(out var table))
-            {
-                return;
-            }
-            foreach (var node in nodes)
-            {
-                if (node is DialogueLineNodeBase dialogueLineNodeBase)
-                {
-                    if (string.IsNullOrEmpty(dialogueLineNodeBase.GetLocalizationTable().TableCollectionName))
-                    {
-                        Debug.LogWarning($"{dialogueLineNodeBase} replace table to {table}");
-                        dialogueLineNodeBase.SetLocalizationTable(table);
-                    }
-                }
-            }
-        }
+
 
         public void Initialize()
         {
@@ -160,12 +142,35 @@ namespace Studio23.SS2.DialogueSystem.Data
             }
             foreach (var node in nodes)
             {
-                if (node is DialogueLineNodeBase dialogueNodeBase)
+                if (node is DialogueLineNodeBase dialogueLineNodeBase)
                 {
-                    dialogueNodeBase.SetLocalizationTable(defaultTable);
+                    dialogueLineNodeBase.SetLocalizationTable(defaultTable);
                     # if UNITY_EDITOR
-                    EditorUtility.SetDirty(dialogueNodeBase);
+                    EditorUtility.SetDirty(dialogueLineNodeBase);
                     #endif
+                }
+            }
+        }
+        
+        [ContextMenu("SET ALL Empty  DIALOGUE TABLES to DEFAULT")]
+        public void SetEmptyDialogueTablesToDefault()
+        {
+            if (!TryGetDefaultTable(out var table))
+            {
+                return;
+            }
+            foreach (var node in nodes)
+            {
+                if (node is DialogueLineNodeBase dialogueLineNodeBase)
+                {
+                    if (string.IsNullOrEmpty(dialogueLineNodeBase.GetLocalizationTable().TableCollectionName))
+                    {
+                        Debug.LogWarning($"{dialogueLineNodeBase} replace table to {table}");
+                        dialogueLineNodeBase.SetLocalizationTable(table);
+# if UNITY_EDITOR
+                        EditorUtility.SetDirty(dialogueLineNodeBase);
+#endif
+                    }
                 }
             }
         }
@@ -178,7 +183,6 @@ namespace Studio23.SS2.DialogueSystem.Data
             }
             foreach (var node in nodes)
             {
-                Debug.Log("node " , node);
                 if (node is DialogueStartNode startNode)
                 {
                     _startNode = startNode;

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Runtime/Data/xNode/Node/DialogueLineNodeBase.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Runtime/Data/xNode/Node/DialogueLineNodeBase.cs
@@ -109,7 +109,8 @@ namespace Studio23.SS2.DialogueSystem.Data
         {
             return DialogueLocalizedString.TableReference;
         }
-        
+
+        public string GetLocalizedLineTextInstant() => DialogueLocalizedString.GetLocalizedString();
         public override void Initialize()
         {
             

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Runtime/Data/xNode/Node/DialogueLineNodeBase.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Runtime/Data/xNode/Node/DialogueLineNodeBase.cs
@@ -4,6 +4,7 @@ using Cysharp.Threading.Tasks;
 using Studio23.SS2.DialogueSystem.Utility;
 using UnityEngine;
 using UnityEngine.Localization;
+using UnityEngine.Localization.Tables;
 using UnityEngine.Serialization;
 using XNode;
 
@@ -98,6 +99,17 @@ namespace Studio23.SS2.DialogueSystem.Data
             return base.GetValue(port);
         }
 
+        public void SetLocalizationTable(TableReference table)
+        {
+            DialogueLocalizedString = new LocalizedString();
+            DialogueLocalizedString.TableReference = table;
+        }
+        
+        public TableReference GetLocalizationTable()
+        {
+            return DialogueLocalizedString.TableReference;
+        }
+        
         public override void Initialize()
         {
             

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table Shared Data.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table Shared Data.asset
@@ -71,6 +71,14 @@ MonoBehaviour:
     m_Key: no just no
     m_Metadata:
       m_Items: []
+  - m_Id: 19520054658248704
+    m_Key: Start 1
+    m_Metadata:
+      m_Items: []
+  - m_Id: 19520788590145536
+    m_Key: Start 2
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table Shared Data.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table Shared Data.asset
@@ -67,6 +67,10 @@ MonoBehaviour:
     m_Key: no wei
     m_Metadata:
       m_Items: []
+  - m_Id: 19497894644461568
+    m_Key: no just no
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table Shared Data.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table Shared Data.asset
@@ -79,6 +79,10 @@ MonoBehaviour:
     m_Key: Start 2
     m_Metadata:
       m_Items: []
+  - m_Id: 23257417221206016
+    m_Key: aaaaa
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table Shared Data.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table Shared Data.asset
@@ -59,6 +59,14 @@ MonoBehaviour:
     m_Key: FINAL CHOICE
     m_Metadata:
       m_Items: []
+  - m_Id: 19494905775042560
+    m_Key: zzzzzz
+    m_Metadata:
+      m_Items: []
+  - m_Id: 19495451646930944
+    m_Key: no wei
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table_en.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table_en.asset
@@ -78,6 +78,10 @@ MonoBehaviour:
     m_Localized: Start
     m_Metadata:
       m_Items: []
+  - m_Id: 23257417221206016
+    m_Localized: aaaaa
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table_en.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table_en.asset
@@ -62,6 +62,14 @@ MonoBehaviour:
     m_Localized: FINAL CHOICE
     m_Metadata:
       m_Items: []
+  - m_Id: 19494905775042560
+    m_Localized: zzzzzz
+    m_Metadata:
+      m_Items: []
+  - m_Id: 19495451646930944
+    m_Localized: no wei
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table_en.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table_en.asset
@@ -70,6 +70,10 @@ MonoBehaviour:
     m_Localized: no wei
     m_Metadata:
       m_Items: []
+  - m_Id: 19497894644461568
+    m_Localized: no just no bu also yes  I  mean yesn't
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table_en.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table_en.asset
@@ -74,6 +74,10 @@ MonoBehaviour:
     m_Localized: no just no bu also yes  I  mean yesn't
     m_Metadata:
       m_Items: []
+  - m_Id: 19520054658248704
+    m_Localized: Start
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table_ja.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Configuration/Localization/New Table_ja.asset
@@ -58,6 +58,10 @@ MonoBehaviour:
     m_Localized: STAND BACK I'M ABOUT TO LOOP
     m_Metadata:
       m_Items: []
+  - m_Id: 19520054658248704
+    m_Localized: Start
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Editor.meta
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Editor.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cef751c3b32f42139d4c7e8260185155
+timeCreated: 1710218967

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Editor/DialogueStartHelperEditor.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Editor/DialogueStartHelperEditor.cs
@@ -1,0 +1,47 @@
+using Studio23.SS2.DialogueSystem.Data;
+using Studio23.SS2.DialogueSystem.Utility;
+using UnityEditor;
+using UnityEngine;
+
+namespace Samples.DialogueChoiceDemo.Editor
+{
+    [CustomEditor(typeof(DialogueStartHelper))]
+    public class DialogueStartHelperEditor: UnityEditor.Editor
+    {
+        private DialogueStartHelper startHelper;
+
+        private void OnEnable()
+        {
+            startHelper = (DialogueStartHelper)target;
+        }
+
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            if (startHelper.Graph == null || startHelper.Graph.nodes == null)
+            {
+                EditorGUILayout.HelpBox("Graph or Nodes not set!", MessageType.Warning);
+                return;
+            }
+
+            EditorGUILayout.Space();
+
+            // Loop through the nodes and create buttons for each
+            foreach (var node in startHelper.Graph.nodes)
+            {
+                if (node is DialogueStartNode startNode)
+                {
+                    if (GUILayout.Button(startNode.DialogueLocalizedString.GetLocalizedStringInEditor()))
+                    {
+                        // If button is clicked, set the node and mark as dirty
+                        Undo.RecordObject(startHelper, "Set Dialogue Node");
+                        startHelper.StartNode = startNode;
+                        EditorUtility.SetDirty(startHelper);
+                    }
+                }
+                
+            }
+        }
+    }
+}

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Editor/DialogueStartHelperEditor.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Editor/DialogueStartHelperEditor.cs
@@ -40,7 +40,6 @@ namespace Samples.DialogueChoiceDemo.Editor
                         EditorUtility.SetDirty(startHelper);
                     }
                 }
-                
             }
         }
     }

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Editor/DialogueStartHelperEditor.cs.meta
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Editor/DialogueStartHelperEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: eadd8373875f49c6ba2a15e6444c42f4
+timeCreated: 1710219123

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2 Shared Data.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2 Shared Data.asset
@@ -1,0 +1,28 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b11a58205ec3474ca216360e9fa74a8, type: 3}
+  m_Name: New Table 2 Shared Data
+  m_EditorClassIdentifier: 
+  m_TableCollectionName: New Table 2
+  m_TableCollectionNameGuidString: c2bd177689020fd468d2d17b65acc54e
+  m_Entries: []
+  m_Metadata:
+    m_Items: []
+  m_KeyGenerator:
+    rid: 9017603091014352904
+  references:
+    version: 2
+    RefIds:
+    - rid: 9017603091014352904
+      type: {class: DistributedUIDGenerator, ns: UnityEngine.Localization.Tables, asm: Unity.Localization}
+      data:
+        m_CustomEpoch: 1710149813216

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2 Shared Data.asset.meta
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2 Shared Data.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c2bd177689020fd468d2d17b65acc54e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5be51871efa6c3e4eae1703925c8f5ac, type: 3}
+  m_Name: New Table 2
+  m_EditorClassIdentifier: 
+  m_SharedTableData: {fileID: 11400000, guid: c2bd177689020fd468d2d17b65acc54e, type: 2}
+  m_Tables:
+  - {fileID: 11400000, guid: 5f49daacee4b45b4a94f58f3c7c49cb7, type: 2}
+  - {fileID: 11400000, guid: b3f1e7a888bb1cd4480171a27de7c79d, type: 2}
+  m_Extensions: []
+  m_Group: String Table
+  references:
+    version: 2
+    RefIds: []

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2.asset.meta
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 12a5f31363523984eb68a2c11de8d3bf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2_en.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2_en.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9620f8c34305754d8cc9a7e49e852d9, type: 3}
+  m_Name: New Table 2_en
+  m_EditorClassIdentifier: 
+  m_LocaleId:
+    m_Code: en
+  m_SharedData: {fileID: 11400000, guid: c2bd177689020fd468d2d17b65acc54e, type: 2}
+  m_Metadata:
+    m_Items: []
+  m_TableData: []
+  references:
+    version: 2
+    RefIds: []

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2_en.asset.meta
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2_en.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f49daacee4b45b4a94f58f3c7c49cb7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2_ja.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2_ja.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9620f8c34305754d8cc9a7e49e852d9, type: 3}
+  m_Name: New Table 2_ja
+  m_EditorClassIdentifier: 
+  m_LocaleId:
+    m_Code: ja
+  m_SharedData: {fileID: 11400000, guid: c2bd177689020fd468d2d17b65acc54e, type: 2}
+  m_Metadata:
+    m_Items: []
+  m_TableData: []
+  references:
+    version: 2
+    RefIds: []

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2_ja.asset.meta
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/New Table 2_ja.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b3f1e7a888bb1cd4480171a27de7c79d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Resources/DialogueSystem/Graphs/Dialogue Graph 1.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Resources/DialogueSystem/Graphs/Dialogue Graph 1.asset
@@ -36,7 +36,10 @@ MonoBehaviour:
       _node: {fileID: -7258830810515598621}
       _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.DialogueLineNodeBase,
         com.studio23.ss2.dialoguesystem, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      connections: []
+      connections:
+      - fieldName: Entry
+        node: {fileID: 6022568079002662684}
+        reroutePoints: []
       _direction: 1
       _connectionType: 1
       _typeConstraint: 2
@@ -365,6 +368,74 @@ MonoBehaviour:
   references:
     version: 2
     RefIds: []
+--- !u!114 &-1934156710639609602
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48d06dc387b74e7488469df7255a04c5, type: 3}
+  m_Name: Bi Way Dialogue
+  m_EditorClassIdentifier: 
+  graph: {fileID: 11400000}
+  position: {x: 278.29416, y: 1606.5487}
+  ports:
+    keys:
+    - Entry
+    - Exit
+    - Events
+    values:
+    - _fieldName: Entry
+      _node: {fileID: -1934156710639609602}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.DialogueLineNodeBase,
+        com.studio23.ss2.dialoguesystem, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections:
+      - fieldName: Exit
+        node: {fileID: 6022568079002662684}
+        reroutePoints: []
+      _direction: 0
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+    - _fieldName: Exit
+      _node: {fileID: -1934156710639609602}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.DialogueLineNodeBase,
+        com.studio23.ss2.dialoguesystem, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections: []
+      _direction: 1
+      _connectionType: 1
+      _typeConstraint: 2
+      _dynamic: 0
+    - _fieldName: Events
+      _node: {fileID: -1934156710639609602}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.EventNodeBase, com.studio23.ss2.dialoguesystem,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections: []
+      _direction: 1
+      _connectionType: 0
+      _typeConstraint: 3
+      _dynamic: 0
+  DialogueLocalizedString:
+    m_TableReference:
+      m_TableCollectionName: GUID:2fefaa175576a0e48bf5b28cb5260137
+    m_TableEntryReference:
+      m_KeyId: 19495451646930944
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  ID: 
+  Reaction: 
+  FMODEvent: 
+  Exit: {fileID: 0}
+  Events: {fileID: 0}
+  Entry: {fileID: 0}
+  references:
+    version: 2
+    RefIds: []
 --- !u!114 &-1822135301059774123
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -482,6 +553,8 @@ MonoBehaviour:
   - {fileID: -2988117806070830359}
   - {fileID: 401710227361937087}
   - {fileID: -1304441183474376835}
+  - {fileID: 6022568079002662684}
+  - {fileID: -1934156710639609602}
   SkippableDialogue: 0
   _startNode: {fileID: -1822135301059774123}
   _conditions: []
@@ -633,6 +706,77 @@ MonoBehaviour:
       m_TableCollectionName: GUID:2fefaa175576a0e48bf5b28cb5260137
     m_TableEntryReference:
       m_KeyId: 714133123072
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  ID: 
+  Reaction: 
+  FMODEvent: 
+  Exit: {fileID: 0}
+  Events: {fileID: 0}
+  Entry: {fileID: 0}
+  references:
+    version: 2
+    RefIds: []
+--- !u!114 &6022568079002662684
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48d06dc387b74e7488469df7255a04c5, type: 3}
+  m_Name: Bi Way Dialogue
+  m_EditorClassIdentifier: 
+  graph: {fileID: 11400000}
+  position: {x: -118.94623, y: 1414.0902}
+  ports:
+    keys:
+    - Entry
+    - Exit
+    - Events
+    values:
+    - _fieldName: Entry
+      _node: {fileID: 6022568079002662684}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.DialogueLineNodeBase,
+        com.studio23.ss2.dialoguesystem, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections:
+      - fieldName: Exit
+        node: {fileID: -7258830810515598621}
+        reroutePoints: []
+      _direction: 0
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+    - _fieldName: Exit
+      _node: {fileID: 6022568079002662684}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.DialogueLineNodeBase,
+        com.studio23.ss2.dialoguesystem, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections:
+      - fieldName: Entry
+        node: {fileID: -1934156710639609602}
+        reroutePoints: []
+      _direction: 1
+      _connectionType: 1
+      _typeConstraint: 2
+      _dynamic: 0
+    - _fieldName: Events
+      _node: {fileID: 6022568079002662684}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.EventNodeBase, com.studio23.ss2.dialoguesystem,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections: []
+      _direction: 1
+      _connectionType: 0
+      _typeConstraint: 3
+      _dynamic: 0
+  DialogueLocalizedString:
+    m_TableReference:
+      m_TableCollectionName: GUID:2fefaa175576a0e48bf5b28cb5260137
+    m_TableEntryReference:
+      m_KeyId: 19494905775042560
       m_Key: 
     m_FallbackState: 0
     m_WaitForCompletion: 0

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Resources/DialogueSystem/Graphs/Dialogue Graph 1.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Resources/DialogueSystem/Graphs/Dialogue Graph 1.asset
@@ -621,6 +621,7 @@ MonoBehaviour:
   - {fileID: 6022568079002662684}
   - {fileID: -1934156710639609602}
   - {fileID: -2134849642463621259}
+  - {fileID: 4547693736577939076}
   SkippableDialogue: 0
   _startNode: {fileID: -1822135301059774123}
   _conditions: []
@@ -714,6 +715,60 @@ MonoBehaviour:
   Events: {fileID: 0}
   ParentChoice: {fileID: 0}
   _conditions: []
+  references:
+    version: 2
+    RefIds: []
+--- !u!114 &4547693736577939076
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 355a0d9d6b03be74a88929f9896d76d4, type: 3}
+  m_Name: Dialogue Start
+  m_EditorClassIdentifier: 
+  graph: {fileID: 11400000}
+  position: {x: -2536, y: 296}
+  ports:
+    keys:
+    - Exit
+    - Events
+    values:
+    - _fieldName: Exit
+      _node: {fileID: 4547693736577939076}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.DialogueLineNodeBase,
+        com.studio23.ss2.dialoguesystem, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections: []
+      _direction: 1
+      _connectionType: 1
+      _typeConstraint: 2
+      _dynamic: 0
+    - _fieldName: Events
+      _node: {fileID: 4547693736577939076}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.EventNodeBase, com.studio23.ss2.dialoguesystem,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections: []
+      _direction: 1
+      _connectionType: 0
+      _typeConstraint: 3
+      _dynamic: 0
+  DialogueLocalizedString:
+    m_TableReference:
+      m_TableCollectionName: GUID:2fefaa175576a0e48bf5b28cb5260137
+    m_TableEntryReference:
+      m_KeyId: 19520054658248704
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  ID: 
+  Reaction: 
+  FMODEvent: 
+  Exit: {fileID: 0}
+  Events: {fileID: 0}
   references:
     version: 2
     RefIds: []

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Resources/DialogueSystem/Graphs/Dialogue Graph 1.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Resources/DialogueSystem/Graphs/Dialogue Graph 1.asset
@@ -368,6 +368,71 @@ MonoBehaviour:
   references:
     version: 2
     RefIds: []
+--- !u!114 &-2134849642463621259
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48d06dc387b74e7488469df7255a04c5, type: 3}
+  m_Name: Bi Way Dialogue
+  m_EditorClassIdentifier: 
+  graph: {fileID: 11400000}
+  position: {x: 617.2541, y: 1142.8558}
+  ports:
+    keys:
+    - Entry
+    - Exit
+    - Events
+    values:
+    - _fieldName: Entry
+      _node: {fileID: -2134849642463621259}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.DialogueLineNodeBase,
+        com.studio23.ss2.dialoguesystem, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections: []
+      _direction: 0
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+    - _fieldName: Exit
+      _node: {fileID: -2134849642463621259}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.DialogueLineNodeBase,
+        com.studio23.ss2.dialoguesystem, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections: []
+      _direction: 1
+      _connectionType: 1
+      _typeConstraint: 2
+      _dynamic: 0
+    - _fieldName: Events
+      _node: {fileID: -2134849642463621259}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.EventNodeBase, com.studio23.ss2.dialoguesystem,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections: []
+      _direction: 1
+      _connectionType: 0
+      _typeConstraint: 3
+      _dynamic: 0
+  DialogueLocalizedString:
+    m_TableReference:
+      m_TableCollectionName: GUID:2fefaa175576a0e48bf5b28cb5260137
+    m_TableEntryReference:
+      m_KeyId: 19497894644461568
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  ID: 
+  Reaction: 
+  FMODEvent: 
+  Exit: {fileID: 0}
+  Events: {fileID: 0}
+  Entry: {fileID: 0}
+  references:
+    version: 2
+    RefIds: []
 --- !u!114 &-1934156710639609602
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -555,6 +620,7 @@ MonoBehaviour:
   - {fileID: -1304441183474376835}
   - {fileID: 6022568079002662684}
   - {fileID: -1934156710639609602}
+  - {fileID: -2134849642463621259}
   SkippableDialogue: 0
   _startNode: {fileID: -1822135301059774123}
   _conditions: []

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Resources/DialogueSystem/Graphs/Dialogue Graph 1.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Resources/DialogueSystem/Graphs/Dialogue Graph 1.asset
@@ -222,6 +222,74 @@ MonoBehaviour:
   references:
     version: 2
     RefIds: []
+--- !u!114 &-6051422413199044520
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48d06dc387b74e7488469df7255a04c5, type: 3}
+  m_Name: Bi Way Dialogue
+  m_EditorClassIdentifier: 
+  graph: {fileID: 11400000}
+  position: {x: 342.01712, y: 253.08244}
+  ports:
+    keys:
+    - Entry
+    - Exit
+    - Events
+    values:
+    - _fieldName: Entry
+      _node: {fileID: -6051422413199044520}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.DialogueLineNodeBase,
+        com.studio23.ss2.dialoguesystem, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections:
+      - fieldName: Exit
+        node: {fileID: 8111244045218751293}
+        reroutePoints: []
+      _direction: 0
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+    - _fieldName: Exit
+      _node: {fileID: -6051422413199044520}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.DialogueLineNodeBase,
+        com.studio23.ss2.dialoguesystem, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections: []
+      _direction: 1
+      _connectionType: 1
+      _typeConstraint: 2
+      _dynamic: 0
+    - _fieldName: Events
+      _node: {fileID: -6051422413199044520}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.EventNodeBase, com.studio23.ss2.dialoguesystem,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections: []
+      _direction: 1
+      _connectionType: 0
+      _typeConstraint: 3
+      _dynamic: 0
+  DialogueLocalizedString:
+    m_TableReference:
+      m_TableCollectionName: GUID:2fefaa175576a0e48bf5b28cb5260137
+    m_TableEntryReference:
+      m_KeyId: 23257417221206016
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  ID: 
+  Reaction: 
+  FMODEvent: 
+  Exit: {fileID: 0}
+  Events: {fileID: 0}
+  Entry: {fileID: 0}
+  references:
+    version: 2
+    RefIds: []
 --- !u!114 &-2988117806070830359
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -622,6 +690,7 @@ MonoBehaviour:
   - {fileID: -1934156710639609602}
   - {fileID: -2134849642463621259}
   - {fileID: 4547693736577939076}
+  - {fileID: -6051422413199044520}
   SkippableDialogue: 0
   _startNode: {fileID: -1822135301059774123}
   _conditions: []
@@ -1019,7 +1088,10 @@ MonoBehaviour:
       _node: {fileID: 8111244045218751293}
       _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.DialogueLineNodeBase,
         com.studio23.ss2.dialoguesystem, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      connections: []
+      connections:
+      - fieldName: Entry
+        node: {fileID: -6051422413199044520}
+        reroutePoints: []
       _direction: 1
       _connectionType: 1
       _typeConstraint: 2

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Resources/DialogueSystem/Graphs/Dialogue Graph 2.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Resources/DialogueSystem/Graphs/Dialogue Graph 2.asset
@@ -273,6 +273,71 @@ MonoBehaviour:
   references:
     version: 2
     RefIds: []
+--- !u!114 &-5729608306176956038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48d06dc387b74e7488469df7255a04c5, type: 3}
+  m_Name: Bi Way Dialogue
+  m_EditorClassIdentifier: 
+  graph: {fileID: 11400000}
+  position: {x: 47.779705, y: 1200.2499}
+  ports:
+    keys:
+    - Entry
+    - Exit
+    - Events
+    values:
+    - _fieldName: Entry
+      _node: {fileID: -5729608306176956038}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.DialogueLineNodeBase,
+        com.studio23.ss2.dialoguesystem, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections: []
+      _direction: 0
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+    - _fieldName: Exit
+      _node: {fileID: -5729608306176956038}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.DialogueLineNodeBase,
+        com.studio23.ss2.dialoguesystem, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections: []
+      _direction: 1
+      _connectionType: 1
+      _typeConstraint: 2
+      _dynamic: 0
+    - _fieldName: Events
+      _node: {fileID: -5729608306176956038}
+      _typeQualifiedName: Studio23.SS2.DialogueSystem.Data.EventNodeBase, com.studio23.ss2.dialoguesystem,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      connections: []
+      _direction: 1
+      _connectionType: 0
+      _typeConstraint: 3
+      _dynamic: 0
+  DialogueLocalizedString:
+    m_TableReference:
+      m_TableCollectionName: 
+    m_TableEntryReference:
+      m_KeyId: 0
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  ID: 
+  Reaction: 
+  FMODEvent: 
+  Exit: {fileID: 0}
+  Events: {fileID: 0}
+  Entry: {fileID: 0}
+  references:
+    version: 2
+    RefIds: []
 --- !u!114 &-2988117806070830359
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -521,6 +586,7 @@ MonoBehaviour:
   - {fileID: -2988117806070830359}
   - {fileID: -7717196668193487428}
   - {fileID: 2612909593522295704}
+  - {fileID: -5729608306176956038}
   SkippableDialogue: 0
   _startNode: {fileID: -1822135301059774123}
   _conditions: []

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Resources/DialogueSystem/Graphs/Dialogue Graph 2.asset
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Resources/DialogueSystem/Graphs/Dialogue Graph 2.asset
@@ -524,6 +524,8 @@ MonoBehaviour:
   SkippableDialogue: 0
   _startNode: {fileID: -1822135301059774123}
   _conditions: []
+  _defaultTable:
+    m_TableCollectionName: New Table
   references:
     version: 2
     RefIds: []

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Scene/SampleScene.unity
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueChoiceDemo/Scene/SampleScene.unity
@@ -1435,6 +1435,52 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1955484839}
   m_CullTransparentMesh: 1
+--- !u!1 &1984308713
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1984308715}
+  - component: {fileID: 1984308714}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1984308714
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1984308713}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b16661fa2d404afebc0acec2a3ee0c88, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _graph: {fileID: 11400000, guid: a52bd472061ea824089a21ac012b405b, type: 2}
+  StartNode: {fileID: 4547693736577939076, guid: a52bd472061ea824089a21ac012b405b, type: 2}
+--- !u!4 &1984308715
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1984308713}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 482.53006, y: 219.4584, z: -257.73752}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -1442,3 +1488,4 @@ SceneRoots:
   - {fileID: 963194228}
   - {fileID: 956320145}
   - {fileID: 1813981468}
+  - {fileID: 1984308715}

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueStartHelper.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueStartHelper.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Studio23.SS2.DialogueSystem.Core;
 using Studio23.SS2.DialogueSystem.Data;
 using UnityEngine;
@@ -21,5 +20,4 @@ namespace Samples
             DialogueSystem.Instance.StartDialogue(_graph);
         }
     }
-    
 }

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueStartHelper.cs
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueStartHelper.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using Studio23.SS2.DialogueSystem.Core;
+using Studio23.SS2.DialogueSystem.Data;
+using UnityEngine;
+
+namespace Samples
+{
+    public class DialogueStartHelper:MonoBehaviour
+    {
+        [SerializeField] private DialogueGraph _graph;
+        public DialogueGraph Graph => _graph;
+        public DialogueNodeBase StartNode;
+
+        public void StartDialogueFromNode()
+        {
+            DialogueSystem.Instance.StartDialogue(_graph, StartNode);
+        }
+        
+        public void StartDialogueFromDefaultStartNode()
+        {
+            DialogueSystem.Instance.StartDialogue(_graph);
+        }
+    }
+    
+}

--- a/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueStartHelper.cs.meta
+++ b/Assets/Packages/com.studio23.ss2.dialoguesystem/Samples/DialogueStartHelper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b16661fa2d404afebc0acec2a3ee0c88
+timeCreated: 1710218777


### PR DESCRIPTION
1. Can write dialogue without needing to setup/open localized string
2. Dialogue is synced with localized string.
3. Custom dialogue node Editor class added.
4. Mutliple start nodes for dialogue
5. Dialogue Start Helper class with custom editor that shows all start nodes and allows selecting one of them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Enhanced dialogue system with support for localized dialogue lines in English and Japanese.
    - Added functionality to start dialogues from specific nodes.
    - Introduced new dialogue nodes and connections for more dynamic conversations.
    - Implemented a new shared data asset for streamlined dialogue configuration.

- **Improvements**
    - Improved editor support for dialogue systems, allowing easier editing and creation of localized dialogue lines.
    - Updated dialogue graphs with new nodes and connections for enriched storytelling.

- **Bug Fixes**
    - Adjusted text color settings in dialogue editor for better visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->